### PR TITLE
systemd unit: catch stdout to avoid useless logs

### DIFF
--- a/root/usr/lib/systemd/system/mattermost.service
+++ b/root/usr/lib/systemd/system/mattermost.service
@@ -10,6 +10,7 @@ ExecStart=/opt/mattermost/bin/mattermost
 PIDFile=/var/spool/mattermost/pid/master.pid
 LimitNOFILE=49152
 Restart=always
+StandardOutput=null
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Mattermost keeps logging useless notification warnings into
/var/log/messages.
This patch just suppress logs like:
```
mattermost: {"level":"warn","ts":1568734300.1634142,"caller":"app/notification.go:333","msg":"Notification not sent",...}
```