### PR TITLE
Mattermost 5.26 with PostgreSQL 12

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ nethserver-mattermost
 Stack:
 
 - Mattermost
-- PostgreSQL 9.4 listening on non-standard port 55432
+- PostgreSQL 12 listening on non-standard port 55434
 - Apache as proxy server
 
 Apache configuration derived from: https://github.com/mattermost/docs/issues/1114

--- a/api/read
+++ b/api/read
@@ -22,7 +22,7 @@
 
 function _query
 {
-    echo $1 | su - postgres  -c "scl enable rh-postgresql94 -- psql  --port=55432 -t -d mattermost 2>/dev/null| tr -d '[:space:]' 2>/dev/null"
+    echo $1 | su - postgres  -c "scl enable rh-postgresql12 -- psql  --port=55434 -t -d mattermost 2>/dev/null| tr -d '[:space:]' 2>/dev/null"
 }
 
 input=$(cat)
@@ -41,7 +41,7 @@ else
     channels=$(_query "select count(*) from channels where deleteat = 0")
     posts=$(_query "select count(*) from posts where deleteat = 0")
 
-    database_usage=$(su - postgres -c "scl enable rh-postgresql94 -- psql -q -A -t --port=55432 -c 'SELECT  pg_database_size('\''mattermost'\'');'")
+    database_usage=$(su - postgres -c "scl enable rh-postgresql12 -- psql -q -A -t --port=55434 -c 'SELECT  pg_database_size('\''mattermost'\'');'")
     data_usage=$(/usr/bin/du -sb /var/lib/nethserver/mattermost | cut -f1)
 
     prop=$(/sbin/e-smith/config getjson mattermost)

--- a/nethserver-mattermost.spec
+++ b/nethserver-mattermost.spec
@@ -1,4 +1,4 @@
-%define mattermost_release 5.25.4
+%define mattermost_release 5.26.2
 
 # HACK: avoid "No build ID note found" error
 %undefine _missing_build_ids_terminate_build
@@ -18,7 +18,7 @@ URL: %{url_prefix}/%{name}
 
 BuildRequires: nethserver-devtools
 
-Requires: nethserver-httpd, nethserver-postgresql94
+Requires: nethserver-httpd, nethserver-postgresql12
 
 %description
 NethServer Mattermost files and configuration.

--- a/root/etc/e-smith/events/actions/nethserver-mattermost-backup
+++ b/root/etc/e-smith/events/actions/nethserver-mattermost-backup
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-su - postgres -c "scl enable rh-postgresql94 -- pg_dump --port 55432 mattermost > /var/lib/nethserver/mattermost/backup/mattermost.sql"
+su - postgres -c "scl enable rh-postgresql12 -- pg_dump --port 55434 mattermost > /var/lib/nethserver/mattermost/backup/mattermost.sql"

--- a/root/etc/e-smith/events/actions/nethserver-mattermost-conf
+++ b/root/etc/e-smith/events/actions/nethserver-mattermost-conf
@@ -20,21 +20,78 @@
 # along with NethServer.  If not, see COPYING.
 #
 
-su - postgres -c "scl enable rh-postgresql94 -- psql --port=55432 -lqt | cut -d \| -f 1 | grep -q -w mattermost"
+echo START //// # ////
+
+su - postgres -c "scl enable rh-postgresql12 -- psql --port=55434 -lqt | cut -d \| -f 1 | grep -q -w mattermost"
 if [ $? -eq 1 ]; then # database do not exists
 
-    # create db and users
-    tmp_sql=`mktemp`
-    chmod a+r $tmp_sql
-    password=`perl -e "use NethServer::Password; print NethServer::Password::store('mattermost');"`
+    echo 2 ////
+
+    su - postgres -c "scl enable rh-postgresql94 -- psql --port=55432 -lqt | cut -d \| -f 1 | grep -q -w mattermost"
+    if [ $? -eq 0 ]; then
+        # migrate data from postgresql 9.4
+        echo "Migrating data from postgresql 9.4 to postgresql 12..."
+        systemctl stop rh-postgresql94-postgresql
+        systemctl stop rh-postgresql12-postgresql
+        su - postgres -c "export LD_LIBRARY_PATH=/opt/rh/rh-postgresql94/root/usr/lib64:/opt/rh/rh-postgresql12/root/usr/lib64:$LD_LIBRARY_PATH && scl enable rh-postgresql12 -- pg_upgrade -b /opt/rh/rh-postgresql94/root/usr/bin -B /opt/rh/rh-postgresql12/root/usr/bin -d /var/opt/rh/rh-postgresql94/lib/pgsql/data -D /var/opt/rh/rh-postgresql12/lib/pgsql/data"
+        if [ $? -eq 0 ]; then
+            echo "Migration completed successfully"
+            # su - postgres -c "/var/lib/pgsql/analyze_new_cluster.sh" # //// needed? generates minimal optimizer statistics
+            systemctl start rh-postgresql94-postgresql
+
+            echo "rh-postgresql94-postgresql started ////"
+
+            databases=$(su - postgres -c "scl enable rh-postgresql94 -- psql -q -A -t --port=55432 -c $'SELECT datname FROM pg_database WHERE datistemplate = false AND datname <> \'postgres\';'")
+
+            if [ $? -eq 0 ]; then
+                if [[ "$databases" == "mattermost" ]]; then
+                    # only mattermost database is present, delete all postgres 9.4 data
+
+                    echo "only mattermost database is present, delete all postgres 9.4 data" ////
+
+                    systemctl stop rh-postgresql94-postgresql
+                    su - postgres -c "/var/lib/pgsql/delete_old_cluster.sh"
+                    /sbin/e-smith/config setprop rh-postgresql94-postgresql status disabled
+                    systemctl disable rh-postgresql94-postgresql
+                    rm -rf /usr/lib/systemd/system/rh-postgresql94-postgresql.service
+                    rm -rf /usr/lib/systemd/system/rh-postgresql94-postgresql@.service
+                    systemctl daemon-reload
+                    # ?? yum remove rh-postgresql94 ////
+
+                    echo "Cleaned rh-postgresql94-postgresql.service ////"
+                else
+                    # other databases are present, delete only mattermost database in postgresql 9.4
+
+                    echo "other databases are present, delete only mattermost database in postgresql 9.4 ////"
+
+                    su - postgres -c "scl enable rh-postgresql94 -- psql -q -A --port=55432 -c 'DROP DATABASE mattermost;'"
+                fi
+            else
+                echo "An error occured while retrieving list of databases  ////"
+            fi
+        else
+            echo "An error occured during postgresql migration"
+        fi
+        systemctl start rh-postgresql12-postgresql
+
+        echo "rh-postgresql12-postgresql started ////"
+
+    else
+
+        echo SKIP ////
+
+        # create db and users
+        tmp_sql=`mktemp`
+        chmod a+r $tmp_sql
+        password=`perl -e "use NethServer::Password; print NethServer::Password::store('mattermost');"`
 cat << EOF > $tmp_sql
 CREATE database mattermost;
 CREATE USER mattuser WITH PASSWORD '$password';
 ALTER USER mattuser WITH SUPERUSER;
 GRANT ALL PRIVILEGES ON DATABASE mattermost to mattuser;
 EOF
-    su - postgres  -c "scl enable rh-postgresql94 -- psql --port=55432 < $tmp_sql" >/dev/null
-    rm -f $tmp_sql
-
+        su - postgres  -c "scl enable rh-postgresql12 -- psql --port=55434 < $tmp_sql" >/dev/null
+        rm -f $tmp_sql
+        fi
 fi
 

--- a/root/etc/e-smith/events/actions/nethserver-mattermost-conf
+++ b/root/etc/e-smith/events/actions/nethserver-mattermost-conf
@@ -21,53 +21,52 @@
 #
 
 su - postgres -c "scl enable rh-postgresql12 -- psql --port=55434 -lqt | cut -d \| -f 1 | grep -q -w mattermost"
-if [ $? -eq 1 ]; then # database do not exists
-    su - postgres -c "scl enable rh-postgresql94 -- psql --port=55432 -lqt | cut -d \| -f 1 | grep -q -w mattermost"
-    if [ $? -eq 0 ]; then
-        echo "Migrating data from postgresql 9.4 to postgresql 12..."
-        systemctl stop rh-postgresql94-postgresql
-        systemctl stop rh-postgresql12-postgresql
-        su - postgres -c "export LD_LIBRARY_PATH=/opt/rh/rh-postgresql94/root/usr/lib64:/opt/rh/rh-postgresql12/root/usr/lib64:$LD_LIBRARY_PATH && scl enable rh-postgresql12 -- pg_upgrade -b /opt/rh/rh-postgresql94/root/usr/bin -B /opt/rh/rh-postgresql12/root/usr/bin -d /var/opt/rh/rh-postgresql94/lib/pgsql/data -D /var/opt/rh/rh-postgresql12/lib/pgsql/data"
-        if [ $? -eq 0 ]; then
-            echo "Migration completed successfully"
-            systemctl start rh-postgresql94-postgresql
-            databases=$(su - postgres -c "scl enable rh-postgresql94 -- psql -q -A -t --port=55432 -c $'SELECT datname FROM pg_database WHERE datistemplate = false AND datname <> \'postgres\';'")
-
-            if [ $? -eq 0 ]; then
-                if [[ "$databases" == "mattermost" ]]; then
-                    # only mattermost database is present, delete all postgres 9.4 data
-                    systemctl stop rh-postgresql94-postgresql
-                    su - postgres -c "/var/lib/pgsql/delete_old_cluster.sh"
-                    /sbin/e-smith/config setprop rh-postgresql94-postgresql status disabled
-                    systemctl disable rh-postgresql94-postgresql
-                    rm -rf /usr/lib/systemd/system/rh-postgresql94-postgresql.service
-                    rm -rf /usr/lib/systemd/system/rh-postgresql94-postgresql@.service
-                    systemctl daemon-reload
-                else
-                    # other databases are present, delete only mattermost database in postgresql 9.4
-                    su - postgres -c "scl enable rh-postgresql94 -- psql -q -A --port=55432 -c 'DROP DATABASE mattermost;'"
-                fi
-            else
-                echo "An error occured while retrieving list of databases"
-            fi
-        else
-            echo "An error occured during postgresql migration"
-        fi
-        systemctl start rh-postgresql12-postgresql
+if [[ $? -eq 0 ]]; then # mattermost database exists, exiting
+    exit 0
+fi
+su - postgres -c "scl enable rh-postgresql94 -- psql --port=55432 -lqt | cut -d \| -f 1 | grep -q -w mattermost"
+if [[ $? -eq 0 ]]; then
+    echo "[NOTICE] Migrating data from postgresql 9.4 to postgresql 12"
+    databases=$(su - postgres -c "scl enable rh-postgresql94 -- psql -q -A -t --port=55432 -c $'SELECT datname FROM pg_database WHERE datistemplate = false AND datname <> \'postgres\';'")
+    if [[ $? -ne 0 ]]; then
+        echo "[ERROR] An error occured while retrieving list of databases"
+        exit 1
+    fi
+    systemctl stop rh-postgresql94-postgresql
+    systemctl stop rh-postgresql12-postgresql
+    su - postgres -c "export LD_LIBRARY_PATH=/opt/rh/rh-postgresql94/root/usr/lib64:/opt/rh/rh-postgresql12/root/usr/lib64:$LD_LIBRARY_PATH && scl enable rh-postgresql12 -- pg_upgrade -b /opt/rh/rh-postgresql94/root/usr/bin -B /opt/rh/rh-postgresql12/root/usr/bin -d /var/opt/rh/rh-postgresql94/lib/pgsql/data -D /var/opt/rh/rh-postgresql12/lib/pgsql/data"
+    if [[ $? -ne 0 ]]; then
+        echo "[ERROR] An error occured during postgresql migration"
+        exit 1
+    fi
+    echo "[NOTICE] Migration completed successfully"
+    if [[ "$databases" == "mattermost" ]]; then
+        # only mattermost database is present, delete all postgres 9.4 data
+        /sbin/e-smith/config setprop rh-postgresql94-postgresql status disabled
+        systemctl disable rh-postgresql94-postgresql
+        rm -rf '/var/opt/rh/rh-postgresql94/lib/pgsql/data'
+        echo "[NOTICE] postgresql 9.4 is no longer needed and has been disabled"
     else
-        echo "Creating mattermost database from scratch..."
-        # create db and users
-        tmp_sql=`mktemp`
-        chmod a+r $tmp_sql
-        password=`perl -e "use NethServer::Password; print NethServer::Password::store('mattermost');"`
-cat << EOF > $tmp_sql
+        echo "[NOTICE] postgresql 9.4 seems to be still used. Removing only mattermost database"
+        systemctl start rh-postgresql94-postgresql
+        sleep 1
+        su - postgres -c "scl enable rh-postgresql94 -- psql -q -A --port=55432 -c 'DROP DATABASE mattermost;'"
+        if [[ $? -ne 0 ]]; then
+            echo "[ERROR] Error while dropping mattermost database"
+        fi
+    fi
+    systemctl start rh-postgresql12-postgresql
+else
+    # create db and users
+    tmp_sql=`mktemp`
+    chmod a+r $tmp_sql
+    password=`perl -e "use NethServer::Password; print NethServer::Password::store('mattermost');"`
+    cat << EOF > $tmp_sql
 CREATE database mattermost;
 CREATE USER mattuser WITH PASSWORD '$password';
 ALTER USER mattuser WITH SUPERUSER;
 GRANT ALL PRIVILEGES ON DATABASE mattermost to mattuser;
 EOF
-        su - postgres  -c "scl enable rh-postgresql12 -- psql --port=55434 < $tmp_sql" >/dev/null
-        rm -f $tmp_sql
-        fi
+    su - postgres  -c "scl enable rh-postgresql12 -- psql --port=55434 < $tmp_sql" >/dev/null
+    rm -f $tmp_sql
 fi
-

--- a/root/etc/e-smith/events/actions/nethserver-mattermost-conf
+++ b/root/etc/e-smith/events/actions/nethserver-mattermost-conf
@@ -47,7 +47,7 @@ if [[ $? -eq 0 ]]; then
         rm -rf '/var/opt/rh/rh-postgresql94/lib/pgsql/data'
         echo "[NOTICE] postgresql 9.4 is no longer needed and has been disabled"
     else
-        echo "[NOTICE] postgresql 9.4 seems to be still used. Removing only mattermost database"
+        echo "[NOTICE] postgresql 9.4 seems to be still in use. Removing only mattermost database"
         systemctl start rh-postgresql94-postgresql
         for ((attempt=1; attempt<=10; a++)); do
             su - postgres  -c "scl enable rh-postgresql94 -- pg_isready -p 55432"

--- a/root/etc/e-smith/events/actions/nethserver-mattermost-conf
+++ b/root/etc/e-smith/events/actions/nethserver-mattermost-conf
@@ -49,7 +49,13 @@ if [[ $? -eq 0 ]]; then
     else
         echo "[NOTICE] postgresql 9.4 seems to be still used. Removing only mattermost database"
         systemctl start rh-postgresql94-postgresql
-        sleep 1
+        for ((attempt=1; attempt<=10; a++)); do
+            su - postgres  -c "scl enable rh-postgresql94 -- pg_isready -p 55432"
+            if [[ $? -eq 0 ]]; then
+                break
+            fi
+            sleep 1
+        done
         su - postgres -c "scl enable rh-postgresql94 -- psql -q -A --port=55432 -c 'DROP DATABASE mattermost;'"
         if [[ $? -ne 0 ]]; then
             echo "[ERROR] Error while dropping mattermost database"

--- a/root/etc/e-smith/events/actions/nethserver-mattermost-conf
+++ b/root/etc/e-smith/events/actions/nethserver-mattermost-conf
@@ -49,7 +49,7 @@ if [[ $? -eq 0 ]]; then
         # only mattermost database is present, delete all postgres 9.4 data
         /sbin/e-smith/config setprop rh-postgresql94-postgresql status disabled
         systemctl disable rh-postgresql94-postgresql
-        rm -rf '/var/opt/rh/rh-postgresql94/lib/pgsql/data/*'
+        rm -rf /var/opt/rh/rh-postgresql94/lib/pgsql/data/*
         echo "[NOTICE] postgresql 9.4 is no longer needed and has been disabled"
     else
         echo "[NOTICE] postgresql 9.4 seems to be still in use. Removing only mattermost database"

--- a/root/etc/e-smith/events/actions/nethserver-mattermost-conf
+++ b/root/etc/e-smith/events/actions/nethserver-mattermost-conf
@@ -20,35 +20,22 @@
 # along with NethServer.  If not, see COPYING.
 #
 
-echo START //// # ////
-
 su - postgres -c "scl enable rh-postgresql12 -- psql --port=55434 -lqt | cut -d \| -f 1 | grep -q -w mattermost"
 if [ $? -eq 1 ]; then # database do not exists
-
-    echo 2 ////
-
     su - postgres -c "scl enable rh-postgresql94 -- psql --port=55432 -lqt | cut -d \| -f 1 | grep -q -w mattermost"
     if [ $? -eq 0 ]; then
-        # migrate data from postgresql 9.4
         echo "Migrating data from postgresql 9.4 to postgresql 12..."
         systemctl stop rh-postgresql94-postgresql
         systemctl stop rh-postgresql12-postgresql
         su - postgres -c "export LD_LIBRARY_PATH=/opt/rh/rh-postgresql94/root/usr/lib64:/opt/rh/rh-postgresql12/root/usr/lib64:$LD_LIBRARY_PATH && scl enable rh-postgresql12 -- pg_upgrade -b /opt/rh/rh-postgresql94/root/usr/bin -B /opt/rh/rh-postgresql12/root/usr/bin -d /var/opt/rh/rh-postgresql94/lib/pgsql/data -D /var/opt/rh/rh-postgresql12/lib/pgsql/data"
         if [ $? -eq 0 ]; then
             echo "Migration completed successfully"
-            # su - postgres -c "/var/lib/pgsql/analyze_new_cluster.sh" # //// needed? generates minimal optimizer statistics
             systemctl start rh-postgresql94-postgresql
-
-            echo "rh-postgresql94-postgresql started ////"
-
             databases=$(su - postgres -c "scl enable rh-postgresql94 -- psql -q -A -t --port=55432 -c $'SELECT datname FROM pg_database WHERE datistemplate = false AND datname <> \'postgres\';'")
 
             if [ $? -eq 0 ]; then
                 if [[ "$databases" == "mattermost" ]]; then
                     # only mattermost database is present, delete all postgres 9.4 data
-
-                    echo "only mattermost database is present, delete all postgres 9.4 data" ////
-
                     systemctl stop rh-postgresql94-postgresql
                     su - postgres -c "/var/lib/pgsql/delete_old_cluster.sh"
                     /sbin/e-smith/config setprop rh-postgresql94-postgresql status disabled
@@ -56,30 +43,19 @@ if [ $? -eq 1 ]; then # database do not exists
                     rm -rf /usr/lib/systemd/system/rh-postgresql94-postgresql.service
                     rm -rf /usr/lib/systemd/system/rh-postgresql94-postgresql@.service
                     systemctl daemon-reload
-                    # ?? yum remove rh-postgresql94 ////
-
-                    echo "Cleaned rh-postgresql94-postgresql.service ////"
                 else
                     # other databases are present, delete only mattermost database in postgresql 9.4
-
-                    echo "other databases are present, delete only mattermost database in postgresql 9.4 ////"
-
                     su - postgres -c "scl enable rh-postgresql94 -- psql -q -A --port=55432 -c 'DROP DATABASE mattermost;'"
                 fi
             else
-                echo "An error occured while retrieving list of databases  ////"
+                echo "An error occured while retrieving list of databases"
             fi
         else
             echo "An error occured during postgresql migration"
         fi
         systemctl start rh-postgresql12-postgresql
-
-        echo "rh-postgresql12-postgresql started ////"
-
     else
-
-        echo SKIP ////
-
+        echo "Creating mattermost database from scratch..."
         # create db and users
         tmp_sql=`mktemp`
         chmod a+r $tmp_sql

--- a/root/etc/e-smith/events/actions/nethserver-mattermost-conf
+++ b/root/etc/e-smith/events/actions/nethserver-mattermost-conf
@@ -20,6 +20,11 @@
 # along with NethServer.  If not, see COPYING.
 #
 
+systemctl is-active --quiet rh-postgresql12-postgresql
+if [[ $? -ne 0 ]]; then
+        echo "[ERROR] postgresql12 is not running, exiting"
+        exit 1
+fi
 su - postgres -c "scl enable rh-postgresql12 -- psql --port=55434 -lqt | cut -d \| -f 1 | grep -q -w mattermost"
 if [[ $? -eq 0 ]]; then # mattermost database exists, exiting
     exit 0
@@ -32,11 +37,11 @@ if [[ $? -eq 0 ]]; then
         echo "[ERROR] An error occured while retrieving list of databases"
         exit 1
     fi
-    systemctl stop rh-postgresql94-postgresql
-    systemctl stop rh-postgresql12-postgresql
+    systemctl stop rh-postgresql94-postgresql rh-postgresql12-postgresql
     su - postgres -c "export LD_LIBRARY_PATH=/opt/rh/rh-postgresql94/root/usr/lib64:/opt/rh/rh-postgresql12/root/usr/lib64:$LD_LIBRARY_PATH && scl enable rh-postgresql12 -- pg_upgrade -b /opt/rh/rh-postgresql94/root/usr/bin -B /opt/rh/rh-postgresql12/root/usr/bin -d /var/opt/rh/rh-postgresql94/lib/pgsql/data -D /var/opt/rh/rh-postgresql12/lib/pgsql/data"
     if [[ $? -ne 0 ]]; then
         echo "[ERROR] An error occured during postgresql migration"
+        systemctl start rh-postgresql94-postgresql rh-postgresql12-postgresql
         exit 1
     fi
     echo "[NOTICE] Migration completed successfully"
@@ -44,18 +49,11 @@ if [[ $? -eq 0 ]]; then
         # only mattermost database is present, delete all postgres 9.4 data
         /sbin/e-smith/config setprop rh-postgresql94-postgresql status disabled
         systemctl disable rh-postgresql94-postgresql
-        rm -rf '/var/opt/rh/rh-postgresql94/lib/pgsql/data'
+        rm -rf '/var/opt/rh/rh-postgresql94/lib/pgsql/data/*'
         echo "[NOTICE] postgresql 9.4 is no longer needed and has been disabled"
     else
         echo "[NOTICE] postgresql 9.4 seems to be still in use. Removing only mattermost database"
         systemctl start rh-postgresql94-postgresql
-        for ((attempt=1; attempt<=10; a++)); do
-            su - postgres  -c "scl enable rh-postgresql94 -- pg_isready -p 55432"
-            if [[ $? -eq 0 ]]; then
-                break
-            fi
-            sleep 1
-        done
         su - postgres -c "scl enable rh-postgresql94 -- psql -q -A --port=55432 -c 'DROP DATABASE mattermost;'"
         if [[ $? -ne 0 ]]; then
             echo "[ERROR] Error while dropping mattermost database"
@@ -63,7 +61,7 @@ if [[ $? -eq 0 ]]; then
     fi
     systemctl start rh-postgresql12-postgresql
 else
-    # create db and users
+    echo "[NOTICE] Creating mattermost database from scratch"
     tmp_sql=`mktemp`
     chmod a+r $tmp_sql
     password=`perl -e "use NethServer::Password; print NethServer::Password::store('mattermost');"`

--- a/root/etc/e-smith/events/actions/nethserver-mattermost-conf-json
+++ b/root/etc/e-smith/events/actions/nethserver-mattermost-conf-json
@@ -60,7 +60,7 @@ if ($data->{'SqlSettings'}->{'DriverName'} ne "postgres") {
 
 # Set database connection string
 $data->{'SqlSettings'}->{'DriverName'} = "postgres";
-$data->{'SqlSettings'}->{'DataSource'} = "postgres://mattuser:$password\@localhost:55432/mattermost?sslmode=disable&connect_timeout=10";
+$data->{'SqlSettings'}->{'DataSource'} = "postgres://mattuser:$password\@localhost:55434/mattermost?sslmode=disable&connect_timeout=10";
 
 # Set data directory
 $data->{'FileSettings'}->{'Directory'} = "/var/lib/nethserver/mattermost/data";

--- a/root/etc/e-smith/events/actions/nethserver-mattermost-restore
+++ b/root/etc/e-smith/events/actions/nethserver-mattermost-restore
@@ -16,7 +16,7 @@ if [ -f /var/lib/nethserver/mattermost/backup/mattermost.sql ]; then
     echo "CREATE database mattermost; CREATE USER mattuser WITH PASSWORD '$password'; GRANT ALL PRIVILEGES ON DATABASE mattermost to mattuser;" >> $drop_sql 
     # allow new connections to db
     echo "UPDATE pg_database SET datallowconn = 'true' WHERE datname = 'mattermost';" >> $drop_sql
-    su - postgres -c "scl enable rh-postgresql94 -- psql --port=55432 < $drop_sql" >/dev/null
-    su - postgres -c "scl enable rh-postgresql94 -- psql --port=55432 mattermost < /var/lib/nethserver/mattermost/backup/mattermost.sql" >/dev/null
+    su - postgres -c "scl enable rh-postgresql12 -- psql --port=55434 < $drop_sql" >/dev/null
+    su - postgres -c "scl enable rh-postgresql12 -- psql --port=55434 mattermost < /var/lib/nethserver/mattermost/backup/mattermost.sql" >/dev/null
     rm -f $drop_sql
 fi

--- a/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/mattermost.rb
+++ b/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/mattermost.rb
@@ -7,11 +7,11 @@ Facter.add('mattermost') do
         mattermost = {}
         pass = File.read("/var/lib/nethserver/secrets/mattermost").strip
 
-        posts = Facter::Core::Execution.exec("psql 'postgresql://mattuser:#{pass}@localhost:55432/mattermost' -Aqt -c 'SELECT count(*) FROM Posts WHERE DeleteAt = 0'")
+        posts = Facter::Core::Execution.exec("psql 'postgresql://mattuser:#{pass}@localhost:55434/mattermost' -Aqt -c 'SELECT count(*) FROM Posts WHERE DeleteAt = 0'")
         mattermost['posts'] = posts.to_i
-        users = Facter::Core::Execution.exec("psql 'postgresql://mattuser:#{pass}@localhost:55432/mattermost' -Aqt -c 'SELECT count(*) FROM Users WHERE DeleteAt = 0'")
+        users = Facter::Core::Execution.exec("psql 'postgresql://mattuser:#{pass}@localhost:55434/mattermost' -Aqt -c 'SELECT count(*) FROM Users WHERE DeleteAt = 0'")
         mattermost['users'] = users.to_i
-        teams = Facter::Core::Execution.exec("psql 'postgresql://mattuser:#{pass}@localhost:55432/mattermost' -Aqt -c 'SELECT count(*) FROM Teams WHERE DeleteAt = 0'")
+        teams = Facter::Core::Execution.exec("psql 'postgresql://mattuser:#{pass}@localhost:55434/mattermost' -Aqt -c 'SELECT count(*) FROM Teams WHERE DeleteAt = 0'")
         mattermost['teams'] = teams.to_i
 
         mattermost

--- a/root/usr/lib/systemd/system/mattermost.service
+++ b/root/usr/lib/systemd/system/mattermost.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Mattermost
-After=syslog.target network.target postgresql-9.4.service
+After=syslog.target network.target rh-postgresql12-postgresql.service
+Wants=rh-postgresql12-postgresql.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
- Migration from PostgreSQL 9.4 to PostgreSQL 12
- Mattermost 5.26 connects to PostgreSQL 12 non-standard port 55434

NethServer/dev#6263