### PR TITLE
Do not inherit system wide encoding for our DB

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-mattermost-conf
+++ b/root/etc/e-smith/events/actions/nethserver-mattermost-conf
@@ -66,7 +66,7 @@ else
     chmod a+r $tmp_sql
     password=`perl -e "use NethServer::Password; print NethServer::Password::store('mattermost');"`
     cat << EOF > $tmp_sql
-CREATE database mattermost;
+CREATE DATABASE mattermost WITH ENCODING 'UTF8' LC_COLLATE='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' TEMPLATE=template0;
 CREATE USER mattuser WITH PASSWORD '$password';
 ALTER USER mattuser WITH SUPERUSER;
 GRANT ALL PRIVILEGES ON DATABASE mattermost to mattuser;

--- a/root/etc/e-smith/events/actions/nethserver-mattermost-restore
+++ b/root/etc/e-smith/events/actions/nethserver-mattermost-restore
@@ -12,8 +12,9 @@ if [ -f /var/lib/nethserver/mattermost/backup/mattermost.sql ]; then
     # drop the db, then recreate it
     echo "DROP DATABASE mattermost;" >> $drop_sql
     echo "DROP USER IF EXISTS mattuser;" >> $drop_sql
+    echo "CREATE DATABASE mattermost WITH ENCODING 'UTF8' LC_COLLATE='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' TEMPLATE=template0;" >> $drop_sql
     password=`perl -e "use NethServer::Password; print NethServer::Password::store('mattermost');"`
-    echo "CREATE database mattermost; CREATE USER mattuser WITH PASSWORD '$password'; GRANT ALL PRIVILEGES ON DATABASE mattermost to mattuser;" >> $drop_sql 
+    echo "CREATE USER mattuser WITH PASSWORD '$password'; GRANT ALL PRIVILEGES ON DATABASE mattermost to mattuser;" >> $drop_sql
     # allow new connections to db
     echo "UPDATE pg_database SET datallowconn = 'true' WHERE datname = 'mattermost';" >> $drop_sql
     su - postgres -c "scl enable rh-postgresql12 -- psql --port=55434 < $drop_sql" >/dev/null


### PR DESCRIPTION
Create the `mattermost` database with explicit en_US.UTF-8 encoding.

https://github.com/NethServer/dev/issues/6286

From PostgreSQL manual:


> By instructing CREATE DATABASE to copy template0 instead of template1, you can create a “virgin” user database that contains none of the site-local additions in template1. This is particularly handy when restoring a pg_dump dump: the dump script should be restored in a virgin database to ensure that one recreates the correct contents of the dumped database, without conflicting with objects that might have been added to template1 later on.

> Another common reason for copying template0 instead of template1 is that new encoding and locale settings can be specified when copying template0, whereas a copy of template1 must use the same settings it does. This is because template1 might contain encoding-specific or locale-specific data, while template0 is known not to.

https://www.postgresql.org/docs/12/manage-ag-templatedbs.html



