### PR TITLE
facter: don't include bots in the users' count

### DIFF
--- a/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/mattermost.rb
+++ b/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/mattermost.rb
@@ -9,7 +9,7 @@ Facter.add('mattermost') do
 
         posts = Facter::Core::Execution.exec("psql 'postgresql://mattuser:#{pass}@localhost:55434/mattermost' -Aqt -c 'SELECT count(*) FROM Posts WHERE DeleteAt = 0'")
         mattermost['posts'] = posts.to_i
-        users = Facter::Core::Execution.exec("psql 'postgresql://mattuser:#{pass}@localhost:55434/mattermost' -Aqt -c 'SELECT count(*) FROM Users WHERE DeleteAt = 0'")
+        users = Facter::Core::Execution.exec("psql 'postgresql://mattuser:#{pass}@localhost:55434/mattermost' -Aqt -c 'SELECT count(*) FROM Users WHERE DeleteAt = 0 and id not in (SELECT userid from Bots)'")
         mattermost['users'] = users.to_i
         teams = Facter::Core::Execution.exec("psql 'postgresql://mattuser:#{pass}@localhost:55434/mattermost' -Aqt -c 'SELECT count(*) FROM Teams WHERE DeleteAt = 0'")
         mattermost['teams'] = teams.to_i


### PR DESCRIPTION
When counting users, filter out the bots' user id by the users ids presents in
the `Bots` table.

See also https://docs.mattermost.com/developer/bot-accounts.html#data-model

NethServer/dev#6312
