### PR TITLE
config: force JSON boolean values

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-mattermost-conf-json
+++ b/root/etc/e-smith/events/actions/nethserver-mattermost-conf-json
@@ -67,10 +67,10 @@ $data->{'FileSettings'}->{'Directory'} = "/var/lib/nethserver/mattermost/data";
 
 # Enable mail and push notifications on the first configuration
 if ($firstRun) {
-  $data->{'EmailSettings'}->{'SendPushNotifications'} = "true";
+  $data->{'EmailSettings'}->{'SendPushNotifications'} = JSON::true;
   $data->{'EmailSettings'}->{'PushNotificationContents'} = "full";
   $data->{'EmailSettings'}->{'PushNotificationServer'} = "https://push.mattermost.com";
-  $data->{'EmailSettings'}->{'SendEmailNotifications'} = "true";
+  $data->{'EmailSettings'}->{'SendEmailNotifications'} = JSON::true;
   $data->{'EmailSettings'}->{'SMTPServer'} = "localhost";
   $data->{'EmailSettings'}->{'SMTPPort'} = "25";
 } else {
@@ -88,8 +88,8 @@ set_if_empty('EmailSettings', 'FeedbackName', "Mattermost $company");
 set_if_empty('EmailSettings', 'FeedbackOrganization', $company);
 
 # Configure logging
-$data->{'LogSettings'}->{'EnableConsole'} = "false";
-set_if_empty('LogSettings', 'EnableFile', 'true');
+$data->{'LogSettings'}->{'EnableConsole'} = JSON::false;
+set_if_empty('LogSettings', 'EnableFile', JSON::true);
 set_if_empty('LogSettings', 'FileLevel', 'error');
 
 # General options


### PR DESCRIPTION
Mattermost is now enforcing the correct boolean type.
This fix prevents the error:
```
Error: failed to load configuration: unable to load on store creation:
parsing error at line 1, character 2339: json: cannot unmarshal string
into Go struct field LogSettings.LogSettings.EnableConsole of type bool
```

NethServer/dev#6372