### PR TITLE
Include mattermost config file in data backup

### DIFF
--- a/root/etc/backup-data.d/mattermost.include
+++ b/root/etc/backup-data.d/mattermost.include
@@ -1,0 +1,1 @@
+/opt/mattermost/config/config.json


### PR DESCRIPTION
NethServer/dev#6644

The config file `/opt/mattermost/config/config.json` is added to data backup by adding it to `/etc/backup-data.d/mattermost.include`.