### PR TITLE
Set X-Forwarded headers for GitLab Auth

### DIFF
--- a/root/etc/e-smith/templates/etc/httpd/conf.d/zz_mattermost.conf/10base
+++ b/root/etc/e-smith/templates/etc/httpd/conf.d/zz_mattermost.conf/10base
@@ -30,6 +30,10 @@
   # Force SSL redirect
   RewriteCond %\{HTTPS\} !=on
   RewriteRule (.*) https://%\{SERVER_NAME\}%\{REQUEST_URI\} [END,QSA,R=permanent]
+  
+  # Pass Forwarded Header
+  RequestHeader set 'X-Forwarded-Proto' 'https'
+  RequestHeader set 'X-Forwarded-SSL' 'on'
 
   <LocationMatch "^/api/v(?<apiversion>[0-9]+)/(?<apiusers>users/)?websocket">
         Require all granted


### PR DESCRIPTION
OAuth requests to GitLab will fail without these headers set. This change will allow people to use GitLab on the same server for SSO with LDAP